### PR TITLE
Move to postgres10 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel8/postgresql-96
+FROM registry.redhat.io/rhel8/postgresql-10
 USER root
 RUN curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | /usr/libexec/platform-python
 ADD Pipfile.lock .


### PR DESCRIPTION
Testing
---------
First, login to registry.redhat.io if you haven't already via `podman login registry.redhat.io`.
Then, build the image via `podman build . -t rhsm-subscriptions-egress`.

Then see that the `aws` command still runs via `podman run --rm -ti rhsm-subscriptions-egress pipenv run aws`