### PR TITLE
Create objects in source in the structure they're expected at the dest

### DIFF
--- a/templates/rhsm-subscriptions-egress.yaml
+++ b/templates/rhsm-subscriptions-egress.yaml
@@ -21,6 +21,7 @@ parameters:
     value: 250m
   - name: CPU_LIMIT
     value: 500m
+  - name: ENVIRONMENT
 
 objects:
 - apiVersion: batch/v1beta1
@@ -48,8 +49,8 @@ objects:
                 for table in $EXPORTED_TABLES; do
                   echo "Table '${table}': Data collection started.";
                   psql -h $POSTGRESQL_SERVICE_HOST -U $POSTGRESQL_USER $POSTGRESQL_DATABASE -c "COPY $table TO STDOUT CSV" |
-                  gzip -9 |
-                  pipenv run aws s3 cp - s3://${S3_BUCKET}/$(date -I)/${table}.csv.gz;
+                  pipenv run aws s3 cp - s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv;
+                  pipenv run aws s3 cp s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv s3://${S3_BUCKET}/${table}/latest/full_data.csv;
                   echo "Table '${table}': Dump uploaded to intermediate storage.";
                 done;
                 echo "Success.";
@@ -98,3 +99,5 @@ objects:
                     key: bucket
               - name: EXPORTED_TABLES
                 value: ${EXPORTED_TABLES}
+              - name: ENVIRONMENT
+                value: ${ENVIRONMENT}


### PR DESCRIPTION
We are changing our S3 sync jobs to do a straight copy of objects from
source to destination bucket. This will make it much easier for us to
maintain the sync jobs, and the sync jobs will be much more fault
tolerant as well.

Because of this change, we can no longer transform the subscription
egress data at sync time. This change updates the export command/job to
place the source objects into the folder structure that the downstream
data consumers expect.