### PR TITLE
Fix the directory for the latest dump

### DIFF
--- a/templates/rhsm-subscriptions-egress.yaml
+++ b/templates/rhsm-subscriptions-egress.yaml
@@ -50,7 +50,7 @@ objects:
                   echo "Table '${table}': Data collection started.";
                   psql -h $POSTGRESQL_SERVICE_HOST -U $POSTGRESQL_USER $POSTGRESQL_DATABASE -c "COPY $table TO STDOUT CSV" |
                   pipenv run aws s3 cp - s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv;
-                  pipenv run aws s3 cp s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv s3://${S3_BUCKET}/${table}/latest/full_data.csv;
+                  pipenv run aws s3 cp s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/latest/full_data.csv;
                   echo "Table '${table}': Dump uploaded to intermediate storage.";
                 done;
                 echo "Success.";


### PR DESCRIPTION
The latest/full_data.csv file for each table is supposed to be placed
under a "directory" for each environment (prod_data or stage_data). This
adds the environment into the path to make it so.