### PR TITLE
Pin pipenv to the latest version that supports Python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.redhat.io/rhel8/postgresql-12
 USER root
-RUN curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | /usr/libexec/platform-python
+RUN curl https://raw.githubusercontent.com/pypa/pipenv/refs/tags/v2024.0.3/get-pipenv.py | /usr/libexec/platform-python
 ADD Pipfile.lock .
 ADD Pipfile .
 RUN pipenv sync --python /usr/libexec/platform-python


### PR DESCRIPTION
Our DB container has Python 3.6 and so we need pipenv to support that. The latest releases now only support back to 3.8.