### PR TITLE
Add headers to csv

### DIFF
--- a/templates/provisional-clowdapp.yaml
+++ b/templates/provisional-clowdapp.yaml
@@ -56,7 +56,7 @@ objects:
               set -ex;
               for table in $EXPORTED_TABLES; do
                 echo "Table '${table}': Data collection started.";
-                psql -h $POSTGRESQL_SERVICE_HOST -U $POSTGRESQL_USER $POSTGRESQL_DATABASE -c "COPY $table TO STDOUT CSV" |
+                psql -h $POSTGRESQL_SERVICE_HOST -U $POSTGRESQL_USER $POSTGRESQL_DATABASE -c "COPY $table TO STDOUT CSV HEADER" |
                 pipenv run aws s3 cp - s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv;
                 pipenv run aws s3 cp s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/latest/full_data.csv;
                 echo "Table '${table}': Dump uploaded to intermediate storage.";

--- a/templates/rhsm-subscriptions-egress.yaml
+++ b/templates/rhsm-subscriptions-egress.yaml
@@ -52,7 +52,7 @@ objects:
                 set -ex;
                 for table in $EXPORTED_TABLES; do
                   echo "Table '${table}': Data collection started.";
-                  psql -h $POSTGRESQL_SERVICE_HOST -U $POSTGRESQL_USER $POSTGRESQL_DATABASE -c "COPY $table TO STDOUT CSV" |
+                  psql -h $POSTGRESQL_SERVICE_HOST -U $POSTGRESQL_USER $POSTGRESQL_DATABASE -c "COPY $table TO STDOUT CSV HEADER" |
                   pipenv run aws s3 cp - s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv;
                   pipenv run aws s3 cp s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/latest/full_data.csv;
                   echo "Table '${table}': Dump uploaded to intermediate storage.";


### PR DESCRIPTION
For fivetran ingestion into S3 we need header values on our CSVs.

Tested against EE instance using:

`psql -h swatch-tally-db -U postgres swatch-tally-db -c "COPY hosts TO STDOUT CSV HEADER"`