### PR TITLE
SWATCH-3399: Bump to Python 3.9 to fix CVE PYSEC-2024-187

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM registry.redhat.io/rhel8/postgresql-12
+FROM registry.redhat.io/rhel9/postgresql-13
 USER root
-RUN curl https://raw.githubusercontent.com/pypa/pipenv/refs/tags/v2024.0.3/get-pipenv.py | /usr/libexec/platform-python
+RUN curl https://raw.githubusercontent.com/pypa/pipenv/refs/tags/v2025.0.2/get-pipenv.py | /usr/libexec/platform-python
 ADD Pipfile.lock .
 ADD Pipfile .
 RUN pipenv sync --python /usr/libexec/platform-python

--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ verify_ssl = true
 awscli = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -18,105 +18,119 @@
     "default": {
         "awscli": {
             "hashes": [
-                "sha256:34c3e8419b4752262443123710a97e58dfd1fa5d1b3f588cd0c711fa463e6044",
-                "sha256:3e4bc43477f5242f0eef631c5c35cc69360524959c2df172f16ab09fe9938407"
+                "sha256:d563a6013326ce689920b56ccd9db024310920cf4b4399d80d75462c27c29328",
+                "sha256:f7cc628f2a7c13b479ca7300de784c62e2bd70da11c1e32e74c2da13a225f685"
             ],
             "index": "pypi",
-            "version": "==1.20.8"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.38.24"
         },
         "botocore": {
             "hashes": [
-                "sha256:437cdcd518e6f9db72ec87f170cc66d54081c8abc347abb9f9a3cd9c8e993bd1",
-                "sha256:e51ac230169af1325ab64c9935e679fb54f6d3fdf0978fe67a31931febdf94f9"
+                "sha256:a0bcc3c376a371f2c11afcbcc9917010c1c0a701d0e45d1ea3ec3bddeb06a8ff",
+                "sha256:f1a55332cca85a6556af8941cccdaf5d2d00336647d9e89f31174f2361ffb4f2"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.21.8"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.37.24"
         },
         "colorama": {
             "hashes": [
-                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
-                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.4.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==0.4.6"
         },
         "docutils": {
             "hashes": [
-                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
-                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
-                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
+                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.15.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.16"
         },
         "jmespath": {
             "hashes": [
-                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
-                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
         },
         "pyasn1": {
             "hashes": [
-                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
-                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
-                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
-                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
-                "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
-                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
-                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
-                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
-                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
-                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
-                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
-                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
-                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
+                "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629",
+                "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"
             ],
-            "version": "==0.4.8"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.6.1"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.9.0.post0"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
-                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
-                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
-                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
-                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
-                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
-                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
-                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
-                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
-                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
-                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
-                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
-                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
-                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
-                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
-                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
-                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
-                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
-                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
-                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
-                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
-                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
-                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
-                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
-                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
-                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
-                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
-                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
-                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+                "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff",
+                "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48",
+                "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086",
+                "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e",
+                "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133",
+                "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5",
+                "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484",
+                "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee",
+                "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5",
+                "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68",
+                "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a",
+                "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf",
+                "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99",
+                "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8",
+                "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85",
+                "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19",
+                "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc",
+                "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a",
+                "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1",
+                "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317",
+                "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c",
+                "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631",
+                "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d",
+                "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652",
+                "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5",
+                "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e",
+                "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b",
+                "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8",
+                "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476",
+                "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706",
+                "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563",
+                "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237",
+                "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b",
+                "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083",
+                "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180",
+                "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425",
+                "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e",
+                "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f",
+                "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725",
+                "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183",
+                "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab",
+                "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774",
+                "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725",
+                "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
+                "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5",
+                "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d",
+                "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290",
+                "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44",
+                "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed",
+                "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4",
+                "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba",
+                "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12",
+                "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==5.4.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==6.0.2"
         },
         "rsa": {
             "hashes": [
@@ -128,27 +142,27 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c",
-                "sha256:9c1dc369814391a6bda20ebbf4b70a0f34630592c9aa520856bf384916af2803"
+                "sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679",
+                "sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.5.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.11.4"
         },
         "six": {
             "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.17.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
-                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
+                "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df",
+                "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.6"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.3.0"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -18,3 +18,55 @@ Prerequisite secrets:
 ```
 oc process -f templates/rhsm-subscriptions-egress.yaml | oc create -f -
 ```
+
+Test Locally
+-------------
+
+0. Be logged to https://access.redhat.com/articles/RegistryAuthentication 
+1. Generate image: `./build_deploy.sh`
+
+Example:
+
+```
+✔ Successfully created virtual environment! 
+Virtualenv location: /var/lib/pgsql/.local/share/virtualenvs/src-dqYAXZ28
+Installing dependencies from Pipfile.lock (94bc2a)...
+To activate this project's virtualenv, run pipenv shell.
+Alternatively, run a command inside the virtualenv with pipenv run.
+All dependencies are now up-to-date!
+--> b07cf440e62f
+STEP 7/8: USER 1001
+--> cfce7cb029bd
+STEP 8/8: CMD /bin/bash
+COMMIT quay.io/cloudservices/rhsm-subscriptions-egress:abffc03
+--> c51e6715032d
+Successfully tagged quay.io/cloudservices/rhsm-subscriptions-egress:abffc03
+```
+
+And export the image to be tested:
+
+```
+export EGRESS_IMAGE=quay.io/cloudservices/rhsm-subscriptions-egress:abffc03
+```
+
+2. Start Up Postgresql (with some tables and data) and Minio to mock S3: `docker compose -f tests/docker-compose.yml up -d`
+3. Run tests: `./run-test.sh`
+
+Expected output:
+
+```
+--- Verifying files in S3 ---
+Checking for historic file: s3://test-bucket/test/table1/historic/2025-05-20-table1.csv
+aws s3 ls s3://test-bucket/test/table1/historic/2025-05-20-table1.csv --endpoint-url=http://localhost:9000
+Historic file for table table1 found.
+Checking for latest file: s3://test-bucket/test/table1/latest/full_data.csv
+aws s3 ls s3://test-bucket/test/table1/latest/full_data.csv --endpoint-url=http://localhost:9000
+Latest file for table 'table1' found:
+Checking for historic file: s3://test-bucket/test/table2/historic/2025-05-20-table2.csv
+aws s3 ls s3://test-bucket/test/table2/historic/2025-05-20-table2.csv --endpoint-url=http://localhost:9000
+Historic file for table table2 found.
+Checking for latest file: s3://test-bucket/test/table2/latest/full_data.csv
+aws s3 ls s3://test-bucket/test/table2/latest/full_data.csv --endpoint-url=http://localhost:9000
+Latest file for table 'table2' found:
+Egress functionality test passed.
+```

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: testuser
+      MINIO_ROOT_PASSWORD: testpassword
+    command: server --console-address ":9001" /minio-data
+
+  postgres:
+    image: postgres:13
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: testuser
+      POSTGRES_PASSWORD: testpassword
+      POSTGRES_DB: testdb
+    volumes:
+      - ./postgres-init:/docker-entrypoint-initdb.d:z

--- a/tests/postgres-init/init.sql
+++ b/tests/postgres-init/init.sql
@@ -1,0 +1,18 @@
+-- postgres-init/init.sql
+CREATE TABLE IF NOT EXISTS table1 (
+    id SERIAL PRIMARY KEY,
+    data TEXT
+);
+
+INSERT INTO table1 (data) VALUES
+('data row 1 for table1'),
+('data row 2 for table1');
+
+CREATE TABLE IF NOT EXISTS table2 (
+    name TEXT PRIMARY KEY,
+    value INTEGER
+);
+
+INSERT INTO table2 (name, value) VALUES
+('row_one', 100),
+('row_two', 200);

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+S3_ENDPOINT="http://localhost:9000"
+S3_ACCESS_KEY="testuser"
+S3_SECRET_KEY="testpassword"
+S3_BUCKET="test-bucket"
+POSTGRESQL_SERVICE_HOST="localhost"
+POSTGRES_PORT=5432
+POSTGRESQL_USER="testuser"
+POSTGRESQL_PASSWORD="testpassword"
+POSTGRESQL_DATABASE="testdb"
+EXPORTED_TABLES="table1 table2"
+ENVIRONMENT="test"
+
+# -- AWS configuration to work with Minio
+aws configure set aws_access_key_id "$S3_ACCESS_KEY"
+aws configure set aws_secret_access_key "$S3_SECRET_KEY"
+
+# --- Functions ---
+test_s3() {
+  echo "--- Testing S3 (minio) ---"
+
+  # Create bucket (ignore if it already exists)
+  aws s3 mb "s3://$S3_BUCKET" --endpoint-url="$S3_ENDPOINT" || true
+
+  # Check if a file exists in S3
+  s3_file_exists() {
+    local bucket="$1"
+    local key="$2"
+    aws s3 ls "s3://${bucket}/${key}" --endpoint-url="$S3_ENDPOINT" > /dev/null 2>&1
+    return $?
+  }
+}
+
+test_egress_functionality() {
+  echo "--- Testing egress functionality ---"
+  # Run the egress image, simulating the cronjob
+  echo "Running the egress image..."
+  docker run --rm --network="host" \
+    -e EXPORTED_TABLES="$EXPORTED_TABLES" \
+    -e S3_BUCKET="$S3_BUCKET" \
+    -e ENVIRONMENT="$ENVIRONMENT" \
+    -e POSTGRESQL_SERVICE_HOST="$POSTGRESQL_SERVICE_HOST" \
+    -e POSTGRESQL_USER="$POSTGRESQL_USER" \
+    -e POSTGRESQL_DATABASE="$POSTGRESQL_DATABASE" \
+    -e POSTGRESQL_PASSWORD="$POSTGRESQL_PASSWORD" \
+    -e S3_ACCESS_KEY="$S3_ACCESS_KEY" \
+    -e S3_SECRET_KEY="$S3_SECRET_KEY" \
+    -e S3_ENDPOINT="$S3_ENDPOINT" \
+    "$EGRESS_IMAGE" sh -c '
+      pipenv run aws configure set aws_access_key_id "$S3_ACCESS_KEY"
+      pipenv run aws configure set aws_secret_access_key "$S3_SECRET_KEY"
+
+      for table in $EXPORTED_TABLES; do
+        echo "Table ${table}: Data collection started.";
+        PGPASSWORD="'"$POSTGRESQL_PASSWORD"'" psql -h $POSTGRESQL_SERVICE_HOST -U $POSTGRESQL_USER -d $POSTGRESQL_DATABASE -c "COPY $table TO STDOUT CSV HEADER" |
+        pipenv run aws s3 cp - s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv --endpoint-url="$S3_ENDPOINT";
+        pipenv run aws s3 cp s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/latest/full_data.csv --endpoint-url="$S3_ENDPOINT";
+        echo "Table ${table}: Dump uploaded to intermediate storage.";
+      done;
+    '
+
+  # Verify that the files were created in S3
+  echo "--- Verifying files in S3 ---"
+  TABLES_ARRAY=($(echo "$EXPORTED_TABLES" | tr ' ' '\n'))
+  for table in "${TABLES_ARRAY[@]}"; do
+    historic_file="s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv"
+    latest_file="s3://${S3_BUCKET}/${ENVIRONMENT}/${table}/latest/full_data.csv"
+
+    echo "Checking for historic file: $historic_file"
+    if test_s3_file_exists "${ENVIRONMENT}/${table}/historic/$(date -I)-${table}.csv"; then
+      echo "Historic file for table $table found."
+    else
+      echo "Error: Historic file for table $table not found."
+      return 1
+    fi
+
+    echo "Checking for latest file: $latest_file"
+    if test_s3_file_exists "${ENVIRONMENT}/${table}/latest/full_data.csv"; then
+      echo "Latest file for table '$table' found."
+    else
+      echo "Error: Latest file for table $table not found."
+      return 1
+    fi
+  done
+
+  echo "Egress functionality test passed."
+}
+
+# Helper function to check if an S3 file exists
+test_s3_file_exists() {
+  local key="$1"
+  echo aws s3 ls "s3://$S3_BUCKET/${key}" --endpoint-url="$S3_ENDPOINT"
+  aws s3 ls "s3://$S3_BUCKET/${key}" --endpoint-url="$S3_ENDPOINT" > /dev/null 2>&1
+  return $?
+}
+
+# --- Main ---
+
+test_s3
+test_egress_functionality


### PR DESCRIPTION
# Description

The CVE PYSEC-2024-187 https://github.com/pypa/virtualenv/issues/2768 is a critical vulnerability in the virtualenv package version 20.17.1 (which is the installed one in Python 3.6). To fix the issue, we need to upgrade it to at least the version 20.26.6. More information about this in: https://quay.io/repository/redhat-services-prod/rh-subs-watch-tenant/rhsm-subscriptions-egress/manifest/sha256:9169013fc90179d29126c0a0427144e39f2f8fea72139f160696aaf7d3c1c470?tab=vulnerabilities&fixable=true

# How to see the virtualenv package version

We can see the actual virtualenv package by adding the following line `RUN /usr/libexec/platform-python -m virtualenv --version` in the Dockerfile and then run the build-images script. You should see:

```
STEP 6/9: RUN /usr/libexec/platform-python -m virtualenv --version
virtualenv 20.17.1 from /usr/local/lib/python3.6/site-packages/virtualenv/__init__.py
```

Where virtualenv 20.17.1 is the problematic package.

# Solution

The problem is that we can't upgrade the virtualenv without bumping Python to 3.9 and we had issues in the past when bumping the python packages (for ex: https://github.com/RedHatInsights/rhsm-subscriptions-egress/pull/72).

Therefore, what I did was to first write a simple test that start up:
- a mock S3 instance using Minio, 
- and a simple postgresql instance with a couple of tables

And write a script to run the generated image of the egress service, connect to the above services and verify that the S3 buckets are generated. 

I wrote the instructions about how to run the test in the README.md.

With this test, I could reproduce the issue after bumping the python dependencies from https://github.com/RedHatInsights/rhsm-subscriptions-egress/pull/72. And I could fix them by upgrading:
- the postgresql client image from registry.redhat.io/rhel8/postgresql-12 to registry.redhat.io/rhel9/postgresql-13
- the latest pipenv installer script
- the Pipfile to use the version 3.9

Now, if we build the images again, including the virtualenv --version line, you should see a most recent version of the virtualenv package. And also, if you run the test script, it should keep working fine as expected.
